### PR TITLE
Не генерировать E_NOTICE при пустой сессии

### DIFF
--- a/init.php
+++ b/init.php
@@ -48,7 +48,7 @@ function logout_user() {
 }
 
 function get_current_user_id() {
-    return (int) $_SESSION['user_id'];
+    return isset($_SESSION['user_id']) ? intval($_SESSION['user_id']) : 0;
 }
 
 function require_login() {


### PR DESCRIPTION
В логе ошибок сервера повторяется вот такое:
PHP Notice:  Undefined index: user_id in tubogram/init.php on line 51
